### PR TITLE
build: simplify test versions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -66,9 +66,7 @@ def version_scheme(version):
     if version.exact:
         return version.format_with("{tag}")
     else:
-        now = datetime.now()
-        seconds = (now.hour * 60) + (now.minute * 60) + now.second
-        return f"{now.year}.{now.month}.{now.day}.{seconds}"
+        return datetime.now().strftime("%Y.%m.%d.%H%M%S%f")
 
 
 setup(


### PR DESCRIPTION
# Description

Why so complex

## Changes

Use `strftime` to generate a date version with basically the same uniqueness

### Checklist

- [ ] This PR has updated documentation
- [ ] This PR has sufficient testing

### Comments

- Nothing here
