### PR TITLE
ci: use pypi token to publish package

### DIFF
--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -34,11 +34,18 @@ jobs:
         COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
       run: |
         make report
-    - name: Run release
-      if:  github.actor != 'dependabot[bot]' && github.actor != 'dependabot-preview[bot]'
+    - name: Dry run release
+      if:  github.ref != 'refs/heads/master' && github.actor != 'dependabot[bot]' && github.actor != 'dependabot-preview[bot]'
       env:
-        TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
-        TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+        TWINE_USERNAME: __token__
+        TWINE_PASSWORD: ${{ secrets.TEST_PYPI_PUBLISH_TOKEN }}
+      run: |
+        make deploy
+    - name: Run release
+      if:  github.ref == 'refs/heads/master' && github.actor != 'dependabot[bot]' && github.actor != 'dependabot-preview[bot]'
+      env:
+        TWINE_USERNAME: __token__
+        TWINE_PASSWORD: ${{ secrets.PYPI_PUBLISH_TOKEN }}
       run: |
         make deploy
   release:


### PR DESCRIPTION
# Description
Stop using user pass auth

## Changes

- Replaced user pass auth with pypi token

### Checklist

- [x] This PR has updated documentation
- [x] This PR has sufficient testing

### Comments

N/A
